### PR TITLE
change EPSG to uppercase in TileMatrixSets

### DIFF
--- a/config/tileMatrixSet/4326.tms
+++ b/config/tileMatrixSet/4326.tms
@@ -1,5 +1,5 @@
 <tileMatrixSet>
-	<crs>epsg:4326</crs>
+	<crs>EPSG:4326</crs>
 	<tileMatrix>
 		<id>0</id>
 		<resolution>0.703125</resolution>

--- a/config/tileMatrixSet/PM.tms
+++ b/config/tileMatrixSet/PM.tms
@@ -1,5 +1,5 @@
 <tileMatrixSet>
-	<crs>epsg:3857</crs>
+	<crs>EPSG:3857</crs>
 	<tileMatrix>
 		<id>0</id>
 		<resolution>156543.0339280410</resolution>


### PR DESCRIPTION
In order to be parsed by OL3 and proj4js, I changed the crs tag in TileMatrixSets with EPSG to use capital letters.
